### PR TITLE
Add Tinybird API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ UPSTASH_REDIS_REST_TOKEN=
 
 # Required for analytics
 TINYBIRD_API_KEY=
+TINYBIRD_API_URL="https://api.tinybird.co"
 
 # Lemon Squeezy - Required for payments
 SQUEEZY_API_KEY=

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -93,7 +93,7 @@ export async function getAnalytics({
 }) {
   try {
     const endpoint = getEndpoint(property, "analytics");
-    const url = new URL(`https://api.tinybird.co/v0/pipes/${endpoint}.json`);
+    const url = new URL(`${process.env.TINYBIRD_API_URL}/v0/pipes/${endpoint}.json`);
 
     url.searchParams.append("type", property);
     if (page) {
@@ -147,7 +147,7 @@ export async function getBookmarkAnalytics({
 }) {
   const endpoint = getEndpoint(property, "bookmarks");
 
-  const url = new URL(`https://api.tinybird.co/v0/pipes/${endpoint}.json`);
+  const url = new URL(`${process.env.TINYBIRD_API_URL}/v0/pipes/${endpoint}.json`);
   url.searchParams.append("id", id);
   url.searchParams.append("type", property);
   if (interval) {

--- a/src/lib/tinybird.ts
+++ b/src/lib/tinybird.ts
@@ -71,7 +71,7 @@ export async function track({
     await Promise.all([
       user.isPro
         ? fetch(
-            `https://api.tinybird.co/v0/events?name=${analyticsSources.analytics}`,
+            `${process.env.TINYBIRD_API_URL}/v0/events?name=${analyticsSources.analytics}`,
             {
               headers: {
                 Authorization: `Bearer ${process.env.TINYBIRD_API_KEY}`,
@@ -153,7 +153,7 @@ export async function recordClick(req: NextRequest, bookmarkId: string) {
     await Promise.all([
       user.isPro
         ? fetch(
-            `https://api.tinybird.co/v0/events?name=${analyticsSources.bookmarks}`,
+            `${process.env.TINYBIRD_API_URL}/v0/events?name=${analyticsSources.bookmarks}`,
             {
               headers: {
                 Authorization: `Bearer ${process.env.TINYBIRD_API_KEY}`,


### PR DESCRIPTION
***Problem:***

The Tinybird API url varies across different regions and cannot be used universally.

***Solution:***

Add an environment variable TINYBIRD_API_URL option for it, making configuration more convenient. Users can obtain the value by selecting "Change provider and region" from the top left corner of the Tinybird page after creating a workspace and then choosing "Copy API URL."